### PR TITLE
Fix LayerRainbow NoSuchMethodException

### DIFF
--- a/src/client/java/com/github/alexthe666/alexsmobs/client/ClientLayerRegistry.java
+++ b/src/client/java/com/github/alexthe666/alexsmobs/client/ClientLayerRegistry.java
@@ -1,7 +1,7 @@
 package com.github.alexthe666.alexsmobs.client;
 
-import com.github.alexthe666.alexsmobs.AlexsMobs;
 import com.github.alexthe666.alexsmobs.client.render.layer.LayerRainbow;
+import com.github.alexthe666.alexsmobs.mixin.LivingEntityRendererAccessor;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 
 /**
@@ -9,14 +9,7 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
  */
 public class ClientLayerRegistry {
 
-    /** Called from mixin when a LivingEntityRenderer is constructed; adds rainbow layer. Fabric: addLayer is protected, use reflection (1:1). */
     public static void addLayerToRenderer(LivingEntityRenderer<?, ?> renderer) {
-        try {
-            java.lang.reflect.Method m = LivingEntityRenderer.class.getDeclaredMethod("addLayer", net.minecraft.client.renderer.entity.layers.RenderLayer.class);
-            m.setAccessible(true);
-            m.invoke(renderer, new LayerRainbow(renderer));
-        } catch (Exception e) {
-            AlexsMobs.LOGGER.warn("Could not add LayerRainbow via reflection", e);
-        }
+        ((LivingEntityRendererAccessor) renderer).alexsmobs$addLayer(new LayerRainbow(renderer));
     }
 }

--- a/src/client/java/com/github/alexthe666/alexsmobs/mixin/LivingEntityRendererAccessor.java
+++ b/src/client/java/com/github/alexthe666/alexsmobs/mixin/LivingEntityRendererAccessor.java
@@ -1,0 +1,13 @@
+package com.github.alexthe666.alexsmobs.mixin;
+
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(LivingEntityRenderer.class)
+public interface LivingEntityRendererAccessor {
+
+    @Invoker("addLayer")
+    boolean alexsmobs$addLayer(RenderLayer<?, ?> layer);
+}

--- a/src/main/resources/alexsmobs.mixins.json
+++ b/src/main/resources/alexsmobs.mixins.json
@@ -1,1 +1,1 @@
-{"required":true,"minVersion":"0.8","package":"com.github.alexthe666.alexsmobs.mixin","compatibilityLevel":"JAVA_17","mixins":["DamageSourceMixin","LivingEntityMixin"],"client":["LivingEntityRendererMixin"],"injectors":{"defaultRequire":1}}
+{"required":true,"minVersion":"0.8","package":"com.github.alexthe666.alexsmobs.mixin","compatibilityLevel":"JAVA_17","mixins":["DamageSourceMixin","LivingEntityMixin"],"client":["LivingEntityRendererMixin","LivingEntityRendererAccessor"],"injectors":{"defaultRequire":1}}


### PR DESCRIPTION
Hi, I'm currently running the latest version of 1.20.1 of Alex's mobs on my Minecraft server. My partners game kept crashing related to the below bug. I see this was fixed in 1.21.1 so I have copied the implementation into this branches version.

I am mainly a .NET dev and have not contributed to a Minecraft mod before so anything you need improving, happy to iterate on this.

I am based in the UK so our time zones may not match up well, I will reply at some point though!

An issue related to this was raised here: https://github.com/astryxion/Alexs-Mobs-Fabric/issues/18.

## Summary
- Replace raw Java reflection in `ClientLayerRegistry` with a Mixin `@Invoker` accessor to call `LivingEntityRenderer.addLayer()`
- The hardcoded string `"addLayer"` in `getDeclaredMethod()` is not remapped by Loom, causing `NoSuchMethodException` at runtime in production (intermediary mappings)
- Backport of 09d9165 from `Fabric-1.21.1`