### PR TITLE
Fix NPE crash when right-clicking a Maned Wolf on the client (26.1)

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityManedWolf.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityManedWolf.java
@@ -312,7 +312,7 @@ public class EntityManedWolf extends Animal implements ITargetsDroppedItems, IDa
     }
 
     public boolean isFood(ItemStack stack) {
-        return !stack.is(AMTagRegistry.MANED_WOLF_STENCH_FOODS) && allFoods.test(stack);
+        return stack.is(AMTagRegistry.MANED_WOLF_BREEDABLES) && !stack.is(AMTagRegistry.MANED_WOLF_STENCH_FOODS);
     }
 
     public void travel(Vec3 vec3d) {
@@ -327,7 +327,7 @@ public class EntityManedWolf extends Animal implements ITargetsDroppedItems, IDa
 
     @Override
     public boolean canTargetItem(ItemStack stack) {
-        return allFoods.test(stack) && !this.isShaking();
+        return (stack.is(AMTagRegistry.MANED_WOLF_BREEDABLES) || stack.is(AMTagRegistry.MANED_WOLF_STENCH_FOODS)) && !this.isShaking();
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes the crash reported in #53: the game crashes instantly when right-clicking a Maned Wolf.

```
java.lang.NullPointerException: Cannot invoke "...Ingredient.test(...)" because "this.allFoods" is null
    at ...EntityManedWolf.isFood(EntityManedWolf.java:315)
    at ...Animal.mobInteract(Animal.java:147)
    at ...EntityManedWolf.mobInteract(EntityManedWolf.java:210)
```

## Root cause

`EntityManedWolf.allFoods` is an instance `Ingredient` that is assigned **only** inside `registerGoals()`. In 26.1 the `Mob` constructor calls `registerGoals()` only when the level is a `ServerLevel` (the call is guarded by `instanceof ServerLevel` in `Mob.<init>`), so on the **client** `allFoods` is never initialized and stays `null`.

Right-clicking the wolf runs `mobInteract` → `isFood()` on the client as well (`MultiPlayerGameMode` predictive interaction), where `allFoods.test(stack)` dereferences the null field and crashes.

Other tamed/breedable mobs (e.g. `EntityCapuchinMonkey`) avoid this because they resolve their ingredient through a lazy, null-checked getter; the Maned Wolf was the only one reading the field directly from a client-reachable predicate.

## Fix

Drop the `allFoods` dependency from the two client-reachable predicates and check the item tags directly:

- `isFood()` → `stack.is(MANED_WOLF_BREEDABLES) && !stack.is(MANED_WOLF_STENCH_FOODS)`
- `canTargetItem()` → `(stack.is(MANED_WOLF_BREEDABLES) || stack.is(MANED_WOLF_STENCH_FOODS)) && !isShaking()`

Tags resolve from the registry on both sides, so this works on the client and server with no dependency on `registerGoals()` having run. `allFoods` is kept for the (server-only) `TemptGoal`, where it is always initialized before use. Behavior is preserved exactly.

## Testing

- `./gradlew build` and `./gradlew runClient` on 26.1 (JDK 25) — compiles and launches.
- Right-clicking a Maned Wolf no longer crashes; no crash report generated and no `allFoods`/`isFood` NPE in the client log.

Fixes #53
