### PR TITLE
Fix Citadel render-state regressions on Fabric 26.1 (baby size, ghost geometry, vanishing entities, animations)

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/AlexsMobsClient.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/AlexsMobsClient.java
@@ -3,7 +3,10 @@ package com.github.alexthe666.alexsmobs;
 import com.github.alexthe666.alexsmobs.client.render.RenderMultipartCollisionPart;
 import com.github.alexthe666.alexsmobs.entity.AMEntityRegistry;
 import com.github.alexthe666.alexsmobs.network.AMNetworking;
+import com.github.alexthe666.citadel.Citadel;
+import com.github.alexthe666.citadel.server.message.AnimationMessage;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 
 public class AlexsMobsClient implements ClientModInitializer {
@@ -12,6 +15,14 @@ public class AlexsMobsClient implements ClientModInitializer {
     public void onInitializeClient() {
         AlexsMobs.PROXY.clientInit();
         AMNetworking.registerClientReceivers();
+        // Citadel's 26.1 Fabric port never wires its own client networking: setClientProxy() is never called
+        // (so Citadel.PROXY stays the no-op ServerProxy) and no client receiver is registered for its S2C
+        // AnimationMessage. As a result server->client animation packets are decoded but dropped, and Citadel
+        // mobs play no scripted animations on a client (e.g. Elephant trumpet/charge/stomp on a server/LAN).
+        // Wire it from here: install the client proxy and route the packet to it on the render thread.
+        Citadel.setClientProxy(new com.github.alexthe666.citadel.ClientProxy());
+        ClientPlayNetworking.registerGlobalReceiver(AnimationMessage.TYPE, (message, context) ->
+                context.client().execute(() -> AnimationMessage.handleClient(message)));
         EntityRendererRegistry.register(AMEntityRegistry.CACHALOT_PART, RenderMultipartCollisionPart::new);
         EntityRendererRegistry.register(AMEntityRegistry.GIANT_SQUID_PART, RenderMultipartCollisionPart::new);
         EntityRendererRegistry.register(AMEntityRegistry.LAVIATHAN_PART, RenderMultipartCollisionPart::new);

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/model/AlexAdvancedEntityModel.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/model/AlexAdvancedEntityModel.java
@@ -2,7 +2,9 @@ package com.github.alexthe666.alexsmobs.client.model;
 
 import com.github.alexthe666.citadel.client.model.AdvancedEntityModel;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.Model;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
@@ -44,6 +46,21 @@ public abstract class AlexAdvancedEntityModel<T extends Entity> extends Advanced
         while (!scratch.isEmpty()) {
             scratch.popPose();
         }
+    }
+
+    /**
+     * Vanilla-{@link Model} counterpart to {@link CitadelEntityModelBridge#submitCitadel}: draws a model from a deferred
+     * {@code submitCustomGeometry} replay using the captured submit {@code pose}. Pass the lambda's {@code pose}, never the
+     * renderer's live {@link PoseStack} (which is usually already popped at replay time, leaving the model at the camera).
+     */
+    public static void submitModel(PoseStack.Pose submitPose, Model model, VertexConsumer buffer, int packedLight, int packedOverlay, int color) {
+        withCitadelSubmitPose(submitPose, new PoseStack(), s -> model.renderToBuffer(s, buffer, packedLight, packedOverlay, color));
+    }
+
+    /** Citadel-{@link AdvancedEntityModel} overload of {@link #submitModel(PoseStack.Pose, Model, VertexConsumer, int, int, int)}
+     * (Citadel models do not extend vanilla {@link Model}). */
+    public static void submitModel(PoseStack.Pose submitPose, AdvancedEntityModel<?> model, VertexConsumer buffer, int packedLight, int packedOverlay, int color) {
+        withCitadelSubmitPose(submitPose, new PoseStack(), s -> model.renderToBuffer(s, buffer, packedLight, packedOverlay, color));
     }
 
     /**

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/CitadelEntityModelBridge.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/CitadelEntityModelBridge.java
@@ -35,6 +35,18 @@ public final class CitadelEntityModelBridge<E extends LivingEntity> extends Enti
     }
 
     /**
+     * Draws the Citadel mesh from a deferred {@link net.minecraft.client.renderer.SubmitNodeCollector#submitCustomGeometry}
+     * replay. The lambda MUST pass its {@code pose} (the captured submit pose) here, never the renderer's live
+     * {@link PoseStack} — the live stack is usually already popped by the time the replay runs, so Citadel (which builds
+     * quads from {@link PoseStack#last()} at draw time) would read a stale/identity transform and draw the mesh at the
+     * camera/origin (stray "ghost" geometry across the screen). See {@link AlexAdvancedEntityModel#withCitadelSubmitPose}.
+     */
+    public void submitCitadel(PoseStack.Pose submitPose, VertexConsumer buffer, int packedLight, int packedOverlay, int color) {
+        AlexAdvancedEntityModel.withCitadelSubmitPose(submitPose, new PoseStack(), s ->
+            this.citadel.renderToBuffer(s, buffer, packedLight, packedOverlay, color));
+    }
+
+    /**
      * Sets {@link AlexAdvancedEntityModel#young} on the wrapped Citadel model (replaces removed {@code EntityModel#young}).
      */
     public void setCitadelYoung(boolean young) {
@@ -49,6 +61,13 @@ public final class CitadelEntityModelBridge<E extends LivingEntity> extends Enti
         }
         @SuppressWarnings("unchecked")
         E entity = (E) raw;
+        // Per-entity baby flag: vanilla 26.1 no longer sets EntityModel#young, and only a handful of
+        // renderers call setCitadelYoung() in extractRenderState. Set it here for every Citadel model so
+        // the shared model's young flag can't leak from the previously rendered entity (babies rendering
+        // adult-sized, or vice versa). Mirrors AlexAdvancedEntityModel.CitadelEntityModelBridge#setupAnim.
+        if (this.citadel instanceof AlexAdvancedEntityModel<?> alex) {
+            alex.young = state.isBaby;
+        }
         float limbSwing = state.walkAnimationPos;
         float limbSwingAmount = Math.min(1.0F, state.walkAnimationSpeed);
         float ageInTicks = state.ageInTicks;

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderAlligatorSnappingTurtle.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderAlligatorSnappingTurtle.java
@@ -65,7 +65,7 @@ public class RenderAlligatorSnappingTurtle
             int color = ARGB.colorFromFloat(1.0F, 1.0F, 1.0F, Math.min(1.0F, mossAlpha));
             this.getParentModel().setupAnim(state);
             bufferIn.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityTranslucent(TEXTURE_MOSS), (pose, mossbuffer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, mossbuffer, packedLightIn, overlay, color));
+                    this.getParentModel().submitCitadel(pose, mossbuffer, packedLightIn, overlay, color));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderBaldEagle.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderBaldEagle.java
@@ -103,7 +103,7 @@ public class RenderBaldEagle extends MobRenderer<EntityBaldEagle, LivingEntityRe
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             bufferIn.submitCustomGeometry(matrixStackIn, RenderTypes.entityTranslucent(TEXTURE_CAP), (pose, lead) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, lead, packedLightIn, overlay, -1));
+                    this.getParentModel().submitCitadel(pose, lead, packedLightIn, overlay, -1));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderBison.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderBison.java
@@ -71,7 +71,7 @@ public class RenderBison extends MobRenderer<EntityBison, LivingEntityRenderStat
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             bufferIn.submitCustomGeometry(matrixStackIn, RenderTypes.entityCutout(tex), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1));
+                    this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, -1));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderBlueJay.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderBlueJay.java
@@ -79,7 +79,7 @@ public class RenderBlueJay extends MobRenderer<EntityBlueJay, LivingEntityRender
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityTranslucent(TEXTURE_SHINY), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, AMColorUtil.packColor(1.0F, 1.0F, 1.0F, alpha)));
+                    this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, AMColorUtil.packColor(1.0F, 1.0F, 1.0F, alpha)));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderCombJelly.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderCombJelly.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelCombJelly;
@@ -86,10 +87,10 @@ public class RenderCombJelly extends MobRenderer<EntityCombJelly, LivingEntityRe
             float wrappedHead = state.yRot;
             STRIPES_MODEL.setupAnim(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, wrappedHead, state.xRot);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.COMBJELLY_RAINBOW_GLINT, (pose, rainbow) ->
-                STRIPES_MODEL.renderToBuffer(matrixStackIn, rainbow, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+                AlexAdvancedEntityModel.submitModel(pose, STRIPES_MODEL, rainbow, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
             );
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(TEXTURE_OVERLAY), (pose, overlay) ->
-                STRIPES_MODEL.renderToBuffer(matrixStackIn, overlay, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+                AlexAdvancedEntityModel.submitModel(pose, STRIPES_MODEL, overlay, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderCrocodile.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderCrocodile.java
@@ -56,7 +56,7 @@ public class RenderCrocodile extends MobRenderer<EntityCrocodile, LivingEntityRe
             matrixStackIn.pushPose();
             this.getParentModel().setupAnim(state);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(TEXTURE_CROWN), (pose, shoeBuffer) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, shoeBuffer, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+                this.getParentModel().submitCitadel(pose, shoeBuffer, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
             );
             matrixStackIn.popPose();
         }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderDropBear.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderDropBear.java
@@ -51,7 +51,7 @@ public class RenderDropBear extends MobRenderer<EntityDropBear, LivingEntityRend
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.eyes(TEXTURE_EYES), (pose, ivertexbuilder) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, ivertexbuilder, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderFrilledShark.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderFrilledShark.java
@@ -58,7 +58,7 @@ public class RenderFrilledShark extends MobRenderer<EntityFrilledShark, LivingEn
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getEyesFlickering(TEXTURE_TEETH, 240), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, 240, overlay, -1));
+                    this.getParentModel().submitCitadel(pose, consumer, 240, overlay, -1));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGiantSquid.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGiantSquid.java
@@ -82,7 +82,7 @@ public class RenderGiantSquid extends MobRenderer<EntityGiantSquid, LivingEntity
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityTranslucent(TEXTURE_DEPRESSURIZED), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, AMColorUtil.packColor(1.0F, 1.0F, 1.0F, alpha)));
+                    this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, AMColorUtil.packColor(1.0F, 1.0F, 1.0F, alpha)));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGrizzlyBear.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGrizzlyBear.java
@@ -70,7 +70,7 @@ public class RenderGrizzlyBear extends MobRenderer<EntityGrizzlyBear, LivingEnti
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             bufferIn.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(TEXTURE_SNOWY), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1));
+                    this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, -1));
         }
     }
 
@@ -90,7 +90,7 @@ public class RenderGrizzlyBear extends MobRenderer<EntityGrizzlyBear, LivingEnti
             int packedColor = AMColorUtil.packColor(1.0F, 1.0F, 1.0F, 0.1F);
             this.getParentModel().setupAnim(state);
             bufferIn.submitCustomGeometry(matrixStackIn, AMRenderTypes.getEyesNoFog(TEXTURE_FREDDY_EYES), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, packedColor));
+                    this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, packedColor));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGust.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGust.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelGuster;
@@ -48,7 +49,7 @@ public class RenderGust extends EntityRenderer<EntityGust, EntityRenderState> {
         this.model.hideEyes();
         int packedLightIn = state.lightCoords;
         collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityTranslucent(TEXTURE), (pose, ivertexbuilder) ->
-            this.model.renderToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+            AlexAdvancedEntityModel.submitModel(pose, this.model, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
         );
         this.model.showEyes();
         matrixStackIn.popPose();

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGuster.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderGuster.java
@@ -72,7 +72,7 @@ public class RenderGuster extends MobRenderer<EntityGuster, LivingEntityRenderSt
             RenderType eyeType = entitylivingbaseIn.getVariant() == 2 ? AMRenderTypes.getEyesNoCull(TEXTURE_SOUL_EYES) : AMRenderTypes.getEyesNoCull(TEXTURE_EYES);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, eyeType, (pose, ivertexbuilder) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, ivertexbuilder, 15728640, overlay, -1)
+                this.getParentModel().submitCitadel(pose, ivertexbuilder, 15728640, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderKomodoDragon.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderKomodoDragon.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelKomodoDragon;
@@ -65,7 +66,7 @@ public class RenderKomodoDragon extends MobRenderer<EntityKomodoDragon, LivingEn
                     parentModel.copyPropertiesTo(MAID_MODEL);
                     MAID_MODEL.prepareMobModel(entitylivingbaseIn, limbSwing, limbSwingAmount, partialTicks);
                     MAID_MODEL.setupAnim(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, wrappedHead, headPitch);
-                    MAID_MODEL.renderToBuffer(matrixStackIn, maid, packedLightIn, overlay, -1);
+                    AlexAdvancedEntityModel.submitModel(pose, MAID_MODEL, maid, packedLightIn, overlay, -1);
                 });
             }
             if (entitylivingbaseIn.isSaddled()) {
@@ -73,7 +74,7 @@ public class RenderKomodoDragon extends MobRenderer<EntityKomodoDragon, LivingEn
                     parentModel.copyPropertiesTo(SADDLE_MODEL);
                     SADDLE_MODEL.prepareMobModel(entitylivingbaseIn, limbSwing, limbSwingAmount, partialTicks);
                     SADDLE_MODEL.setupAnim(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, wrappedHead, headPitch);
-                    SADDLE_MODEL.renderToBuffer(matrixStackIn, saddle, packedLightIn, overlay, -1);
+                    AlexAdvancedEntityModel.submitModel(pose, SADDLE_MODEL, saddle, packedLightIn, overlay, -1);
                 });
             }
         }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderMoose.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderMoose.java
@@ -57,7 +57,7 @@ public class RenderMoose extends MobRenderer<EntityMoose, LivingEntityRenderStat
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(tex), (pose, ivertexbuilder) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, ivertexbuilder, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderPlatypus.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderPlatypus.java
@@ -57,7 +57,7 @@ public class RenderPlatypus extends MobRenderer<EntityPlatypus, LivingEntityRend
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityCutout(FEDORA_TEXTURE), (pose, ivertexbuilder) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, ivertexbuilder, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderPollenBall.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderPollenBall.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelPollenBall;
@@ -46,7 +47,7 @@ public class RenderPollenBall extends EntityRenderer<EntityPollenBall, EntityRen
         matrixStackIn.scale(1F, 1F, 1F);
         int packedLightIn = state.lightCoords;
         collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getFullBright(getTextureLocation(state)), (pose, ivertexbuilder) ->
-            MODEL_POLLEN_BALL.renderToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+            AlexAdvancedEntityModel.submitModel(pose, MODEL_POLLEN_BALL, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
         );
         matrixStackIn.popPose();
         matrixStackIn.popPose();

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderSandShot.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderSandShot.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.entity.EntityGuster;
@@ -54,7 +55,7 @@ public class RenderSandShot extends EntityRenderer<EntitySandShot, LlamaSpitRend
         this.model.setupAnim(state);
         int packedLightIn = state.lightCoords;
         collector.submitCustomGeometry(matrixStackIn, this.model.renderType(SAND_SHOT), (pose, ivertexbuilder) ->
-            this.model.renderToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+            AlexAdvancedEntityModel.submitModel(pose, this.model, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
         );
         matrixStackIn.popPose();
         super.submit(state, matrixStackIn, collector, cameraState);

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderSeal.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderSeal.java
@@ -105,7 +105,7 @@ public class RenderSeal extends MobRenderer<EntitySeal, LivingEntityRenderState,
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(TEXTURE_TEARS), (pose, lead) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, lead, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, lead, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderStraddleboard.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderStraddleboard.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelStraddleboard;
@@ -67,11 +68,11 @@ public class RenderStraddleboard extends EntityRenderer<EntityStraddleboard, Ent
         matrixStackIn.translate(0, -1.5F - Math.abs(boardRot * 0.007F) - (lava ? 0 : 0.25F), 0);
         BOARD_MODEL.animateBoard(entityIn, entityIn.tickCount + partialTicks);
         collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(TEXTURE_OVERLAY), (pose, ivertexbuilder2) ->
-            BOARD_MODEL.renderToBuffer(matrixStackIn, ivertexbuilder2, packedLightIn, NO_OVERLAY, -1)
+            AlexAdvancedEntityModel.submitModel(pose, BOARD_MODEL, ivertexbuilder2, packedLightIn, NO_OVERLAY, -1)
         );
         int color = (255 << 24) | ((int) (r * 255) << 16) | ((int) (g * 255) << 8) | (int) (b * 255);
         collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityTranslucentCullItemTarget(TEXTURE), (pose, ivertexbuilder) ->
-            BOARD_MODEL.renderToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, NO_OVERLAY, color)
+            AlexAdvancedEntityModel.submitModel(pose, BOARD_MODEL, ivertexbuilder, packedLightIn, NO_OVERLAY, color)
         );
         matrixStackIn.popPose();
         matrixStackIn.popPose();

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderStraddler.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderStraddler.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelStraddler;
@@ -58,7 +59,7 @@ public class RenderStraddler extends MobRenderer<EntityStraddler, LivingEntityRe
                 matrixStackIn.translate(0F, -2.5F + back * 0.5F, 0.35F + back);
                 int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
                 collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityTranslucent(RenderStradpole.TEXTURE), (pose, ivertexbuilder) ->
-                    STRADPOLE_MODEL.renderToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, overlay, -1)
+                    AlexAdvancedEntityModel.submitModel(pose, STRADPOLE_MODEL, ivertexbuilder, packedLightIn, overlay, -1)
                 );
                 matrixStackIn.popPose();
             }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderTossedItem.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderTossedItem.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelAncientDart;
@@ -58,7 +59,7 @@ public class RenderTossedItem extends EntityRenderer<EntityTossedItem, EntityRen
             matrixStackIn.translate(0, 0.5F, 0);
             matrixStackIn.scale(1F, 1F, 1F);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(DART_TEXTURE), (pose, ivertexbuilder) ->
-                DART_MODEL.renderToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
+                AlexAdvancedEntityModel.submitModel(pose, DART_MODEL, ivertexbuilder, packedLightIn, OverlayTexture.NO_OVERLAY, -1)
             );
             matrixStackIn.popPose();
         } else {

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderToucan.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderToucan.java
@@ -78,10 +78,10 @@ public class RenderToucan extends MobRenderer<EntityToucan, LivingEntityRenderSt
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.armorCutoutNoCull(TEXTURE_GOLDEN), (pose, baseVc) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, baseVc, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, baseVc, packedLightIn, overlay, -1)
             );
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.armorEntityGlint(), (pose, glintVc) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, glintVc, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, glintVc, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderVoidWormShot.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderVoidWormShot.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelVoidWormShot;
@@ -55,7 +56,7 @@ public class RenderVoidWormShot extends EntityRenderer<EntityVoidWormShot, Entit
         float colorize = home;
         matrixStackIn.translate(0, -1.5F, 0);
         collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getFullBright(TEXTURE), (pose, ivertexbuilder) ->
-            MODEL.renderToBuffer(matrixStackIn, ivertexbuilder, 210, NO_OVERLAY, -1)
+            AlexAdvancedEntityModel.submitModel(pose, MODEL, ivertexbuilder, 210, NO_OVERLAY, -1)
         );
         matrixStackIn.popPose();
         matrixStackIn.popPose();

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderWarpedMosco.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderWarpedMosco.java
@@ -50,7 +50,7 @@ public class RenderWarpedMosco extends MobRenderer<EntityWarpedMosco, LivingEnti
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             int packedColor = AMColorUtil.packColor(0.5F, 1.0F, 1.0F, alpha);
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getEyesFlickering(TEXTURE_EYES, 0), (pose, ivertexbuilder) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, ivertexbuilder, 240, overlay, packedColor)
+                this.getParentModel().submitCitadel(pose, ivertexbuilder, 240, overlay, packedColor)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerBasicGlow.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerBasicGlow.java
@@ -23,6 +23,6 @@ public class LayerBasicGlow<E extends Mob> extends RenderLayer<LivingEntityRende
     public void submit(PoseStack matrixStackIn, SubmitNodeCollector collector, int packedLightIn, LivingEntityRenderState state, float netHeadYaw, float headPitch) {
         this.getParentModel().setupAnim(state);
         collector.submitCustomGeometry(matrixStackIn, RenderTypes.eyes(this.texture), (pose, consumer) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, OverlayTexture.NO_OVERLAY, -1));
+                this.getParentModel().submitCitadel(pose, consumer, packedLightIn, OverlayTexture.NO_OVERLAY, -1));
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerCapuchinItem.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerCapuchinItem.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render.layer;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelAncientDart;
@@ -63,7 +64,7 @@ public class LayerCapuchinItem extends RenderLayer<LivingEntityRenderState, Cita
             matrixStackIn.pushPose();
             matrixStackIn.mulPose(Axis.XP.rotationDegrees(f));
             bufferIn.submitCustomGeometry(matrixStackIn, RenderTypes.entityCutout(DART_TEXTURE), (pose, consumer) ->
-                    DART_MODEL.renderToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1));
+                    AlexAdvancedEntityModel.submitModel(pose, DART_MODEL, consumer, packedLightIn, overlay, -1));
             matrixStackIn.popPose();
             matrixStackIn.popPose();
 

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerCockroachMaracas.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerCockroachMaracas.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render.layer;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelCockroach;
@@ -90,7 +91,7 @@ public class LayerCockroachMaracas extends RenderLayer<LivingEntityRenderState, 
             matrixStackIn.scale(0.8F, 0.8F, 0.8F);
             matrixStackIn.mulPose(Axis.XP.rotationDegrees(60F * entitylivingbaseIn.danceProgress * 0.2F));
             bufferIn.submitCustomGeometry(matrixStackIn, AMRenderTypes.entityCutoutNoCull(SOMBRERO_TEX), (pose, consumer) ->
-                    sombrero.renderToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1));
+                    AlexAdvancedEntityModel.submitModel(pose, sombrero, consumer, packedLightIn, overlay, -1));
             matrixStackIn.popPose();
         }
         matrixStackIn.popPose();

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerElephantOverlays.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerElephantOverlays.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render.layer;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelElephant;
@@ -40,7 +41,7 @@ public class LayerElephantOverlays extends RenderLayer<LivingEntityRenderState, 
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             this.getParentModel().setupAnim(state);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityCutout(TEXTURE_CHEST), (pose, consumer) ->
-                    this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1));
+                    this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, -1));
         }
         DyeColor lvt_11_1_ = elephant.getColor();
         if (lvt_11_1_ != null || elephant.isTrader()) {
@@ -54,7 +55,7 @@ public class LayerElephantOverlays extends RenderLayer<LivingEntityRenderState, 
             ((ModelElephant) this.getParentModel().citadel()).copyPropertiesTo(this.model);
             this.model.setupAnim(elephant, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityCutout(lvt_12_3_), (pose, consumer) ->
-                    this.model.renderToBuffer(matrixStackIn, consumer, packedLightIn, OverlayTexture.NO_OVERLAY, -1));
+                    AlexAdvancedEntityModel.submitModel(pose, this.model, consumer, packedLightIn, OverlayTexture.NO_OVERLAY, -1));
         }
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerEndergradeSaddle.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerEndergradeSaddle.java
@@ -28,6 +28,6 @@ public class LayerEndergradeSaddle extends RenderLayer<LivingEntityRenderState, 
         int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         this.getParentModel().setupAnim(state);
         collector.submitCustomGeometry(matrixStackIn, RenderTypes.entityCutout(TEXTURE), (pose, consumer) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1));
+                this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, -1));
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerRaccoonEyes.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerRaccoonEyes.java
@@ -42,7 +42,7 @@ public class LayerRaccoonEyes extends RenderLayer<LivingEntityRenderState, Citad
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.eyes(TEXTURE), (pose, ivertexbuilder) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, ivertexbuilder, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, ivertexbuilder, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerSoulVultureGlow.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerSoulVultureGlow.java
@@ -31,11 +31,11 @@ public class LayerSoulVultureGlow extends RenderLayer<LivingEntityRenderState, C
         this.getParentModel().setupAnim(state);
         int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getGhost(TEXTURE_GLOW), (pose, consumer) ->
-            this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, 240, overlay, -1)
+            this.getParentModel().submitCitadel(pose, consumer, 240, overlay, -1)
         );
         if (entitylivingbaseIn.hasSoulHeart()) {
             collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getGhost(getFlames(entitylivingbaseIn.tickCount)), (pose, consumer) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, 240, overlay, -1)
+                this.getParentModel().submitCitadel(pose, consumer, 240, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerTigerEyes.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerTigerEyes.java
@@ -45,7 +45,7 @@ public class LayerTigerEyes extends RenderLayer<LivingEntityRenderState, Citadel
             this.getParentModel().setupAnim(state);
             int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
             collector.submitCustomGeometry(matrixStackIn, RenderTypes.eyes(texture), (pose, consumer) ->
-                this.getParentModel().renderCitadelToBuffer(matrixStackIn, consumer, packedLightIn, overlay, -1)
+                this.getParentModel().submitCitadel(pose, consumer, packedLightIn, overlay, -1)
             );
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerWarpedToadGlow.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/layer/LayerWarpedToadGlow.java
@@ -1,4 +1,5 @@
 package com.github.alexthe666.alexsmobs.client.render.layer;
+import com.github.alexthe666.alexsmobs.client.model.AlexAdvancedEntityModel;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
 import com.github.alexthe666.alexsmobs.client.model.ModelWarpedToad;
@@ -33,7 +34,7 @@ public class LayerWarpedToadGlow extends RenderLayer<LivingEntityRenderState, Ci
         final float alpha = 0.75F + (Mth.cos(state.ageInTicks * 0.2F) + 1F) * 0.125F;
         int overlay = LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         collector.submitCustomGeometry(matrixStackIn, AMRenderTypes.getEyesFlickering(entitylivingbaseIn.isBlinking() ? TEXTURE_BLINKING : TEXTURE, 0), (pose, ivertexbuilder) ->
-            model.renderToBuffer(matrixStackIn, ivertexbuilder, 240, overlay, -1)
+            AlexAdvancedEntityModel.submitModel(pose, model, ivertexbuilder, 240, overlay, -1)
         );
     }
 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/mixin/client/EntityRenderDispatcherStateCaptureMixin.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/mixin/client/EntityRenderDispatcherStateCaptureMixin.java
@@ -1,12 +1,17 @@
 package com.github.alexthe666.alexsmobs.mixin.client;
 
 import com.github.alexthe666.alexsmobs.client.AlexsMobsClientKeys;
+import com.github.alexthe666.alexsmobs.ClientProxy;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(EntityRenderDispatcher.class)
@@ -16,5 +21,16 @@ public class EntityRenderDispatcherStateCaptureMixin {
     private void alexsmobs$captureEntityForState(Entity entity, float partialTicks, CallbackInfoReturnable<EntityRenderState> cir) {
         EntityRenderState state = cir.getReturnValue();
         AlexsMobsClientKeys.setEntity(state, entity);
+    }
+
+    /**
+     * Capture the current world-render camera so {@link ClientProxy#submitEntityInWorld} can render entities manually
+     * (pouch babies, whale-captured squid). Without this, {@code lastCameraRenderState} stays null and every manual
+     * render silently no-ops, so those entities vanish entirely. Runs at HEAD of every entity submit, so the camera is
+     * already set before any render layer fires.
+     */
+    @Inject(method = "submit", at = @At("HEAD"))
+    private void alexsmobs$captureCameraForState(EntityRenderState state, CameraRenderState camera, double x, double y, double z, PoseStack poseStack, SubmitNodeCollector collector, CallbackInfo ci) {
+        ClientProxy.lastCameraRenderState = camera;
     }
 }


### PR DESCRIPTION
## Fix Citadel render-state regressions on Fabric 26.1

Several client-side Citadel mechanisms were left wired incompletely in the 26.1 render-state port. This restores them.

### What's fixed
1. **Baby model size.** `EntityModel#young` is gone in 26.1 and only a few renderers set it via `setCitadelYoung()`, so most Citadel models never got a per-entity baby flag and the shared model's `young` leaked between entities (babies rendering adult-sized, or adults baby-sized). Now set centrally in `CitadelEntityModelBridge#setupAnim` (`young = state.isBaby`).
   *Related to (previously closed) #23 and #48, the "adult model" half of (closed) #32, and item 1 of #36.*

2. **Ghost geometry / phantom mobs (~40 sites).** Deferred `submitCustomGeometry` lambdas drew with the captured live `PoseStack` instead of the replay `pose`. The live stack is usually already popped when the deferred replay runs, so Citadel (which builds quads from `PoseStack#last()` at draw time) read a stale/identity transform and drew the mesh at the camera/origin — the white squid stuck to the view, bear-snow smear, screen-covering glow overlays, etc. Added `submitCitadel(pose, …)` / `submitModel(pose, …)` helpers that draw through `withCitadelSubmitPose()`, and routed every offending layer/renderer through them.
   *Addresses #49 and the squid / Soul-Vulture / ghost-texture items of #36.*

3. **Vanishing manually-rendered entities.** `ClientProxy.lastCameraRenderState` was never assigned, so `submitEntityInWorld()` always hit its null-camera guard and silently no-oped — whale-captured squid and pouch babies rendered nothing. Now captured via a mixin at the head of every entity submit.
   *Related to (previously closed) #32 — anteater baby goes invisible after the adult it rides is killed.*

4. **Mob animations not playing on clients.** Citadel's 26.1 Fabric port registers the `AnimationMessage` S2C codec but never wires the client side (`setClientProxy()` is never called and no `ClientPlayNetworking` receiver is registered), so scripted animations never play on a client (e.g. the Elephant's trumpet/charge on a server/LAN). Wired from Alex's Mobs' client initializer. *(Not previously filed as a separate issue.)*

### Known remaining (tracked in #61)
Cockroach sombrero placement, kangaroo pouch-baby position (`renderOnlyHead` + bone-walk), and the enchanted-toucan glint double — all 26.1 deferred-pipeline bone-walk/shared-model edge cases that need runtime debugging. The cockroach and kangaroo items are the remaining ones from #49 (every item of #36 is fixed above); the enchanted-toucan double was found during testing and isn't in an existing report. The **End Pirate** renderers (anchor, winch, ship wheel, flag, door) are deliberately left untouched: End Pirate is scrapped/unused content (per the mod wiki's Scrapped Features list), and all five of its block-entity types are commented out in `AMTileEntityRegistry` (`= null`), so none of those renderers run and the blocks/items are unobtainable. Dead code, not a render bug; noted for completeness.

### ⚠️ Disclosure on how this was made
This was **"vibe coded"** — written with heavy AI assistance. It was **manually tested in-dev** (`runClient`), and the fixes are based on code analysis against the upstream Forge sources. However, **I have not played the original mod myself**, and I only used **screenshots** as references for what the correct visuals should look like. Please review carefully and treat the visual behavior as needing a second pair of eyes from someone familiar with the mod before merging.



### Testing & Citadel-version note
All testing was done in the dev environment (`runClient`), which bundles **Citadel 1.0.0** (this repo's subproject). The other fixes here are independent of the Citadel version, but the **animation fix** (the "Mob animations not playing on clients" item above) is really a Citadel-side gap: Citadel never registers a client `ClientPlayNetworking` receiver for its own `AnimationMessage`. I verified by bytecode that this is still missing in the current CurseForge **Citadel 1.0.2** — 1.0.2 added the `setClientProxy()` call but still registers no client receiver — so server→client animation packets are dropped on both 1.0.0 and 1.0.2, and the receiver had to be wired from Alex's Mobs as a stopgap.

**This animation wiring arguably belongs in the Citadel repo instead** (`citadel:animation` is a Citadel feature). Against 1.0.2 it's non-conflicting (1.0.2 registers no such receiver, so no duplicate), but it was **not** runtime-tested with 1.0.2 — only with the bundled 1.0.0. Caveat: if a future Citadel adds its own `AnimationMessage` client receiver, the `AlexsMobsClient` registration becomes a redundant duplicate and should be dropped.
