### PR TITLE
Fix anvil enchanted book merging (Fixes #74)

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/mixin/AnvilMenuMixin.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/mixin/AnvilMenuMixin.java
@@ -12,23 +12,20 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 import java.util.Map;
 
 /**
- * Vanilla anvil logic can skip {@link Enchantment#canEnchant(ItemStack)} when the target is an
- * enchanted book or the player is in creative. Strip invalid enchantments before applying.
+ * Vanilla anvil logic can skip {@link Enchantment#canEnchant(ItemStack)} when
+ * the target is an
+ * enchanted book or the player is in creative. Strip invalid enchantments
+ * before applying.
  */
 @Mixin(AnvilMenu.class)
 public class AnvilMenuMixin {
 
-    @ModifyArgs(
-            method = "createResult",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;setEnchantments(Ljava/util/Map;Lnet/minecraft/world/item/ItemStack;)V"
-            )
-    )
+    @ModifyArgs(method = "createResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;setEnchantments(Ljava/util/Map;Lnet/minecraft/world/item/ItemStack;)V"))
     private static void alexsmobs$filterAnvilEnchantments(Args args) {
         @SuppressWarnings("unchecked")
         Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) args.get(0);
         ItemStack stack = (ItemStack) args.get(1);
-        enchantments.entrySet().removeIf(entry -> !entry.getKey().canEnchant(stack));
+        if (!stack.is(net.minecraft.world.item.Items.ENCHANTED_BOOK))
+            enchantments.entrySet().removeIf(entry -> !entry.getKey().canEnchant(stack));
     }
 }


### PR DESCRIPTION
## About the PR
Fixes #74. Resolves an issue where merging two enchanted/spell books in an anvil resulted in the output book only keeping the first book's enchantments, instead of combining both.

## Technical details
In `AnvilMenuMixin`, the custom filtering logic was checking if each enchantment `canEnchant` the output `ItemStack`. 
Since an enchanted book target returns `false` for `canEnchant` on normal gear enchantments, the mixin was filtering them out. Added a check to bypass this filter when the target stack is an `ENCHANTED_BOOK`.
